### PR TITLE
Add ARIA DOM attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,18 +291,19 @@ maxLength media minLength role rows seamless size sizes srcSet width checked
 controls loop multiple readOnly selected srcDoc value
 ```
 
-Adding `data-*` attributes requires passing an object to the `data` attribute. For example,
+Adding `aria-*` or `data-*` attributes requires passing an object to the attribute. For example,
 
 ```js
+const aria = {hidden: false}
 const data = {cool: `dude`, veryRad: `gal`}
 
-<div data={data} />
+<div aria={aria} data={data} />
 ```
 
-will render
+will render,
 
 ```html
-<div data-cool="dude" data-very-rad="gal"></div>
+<div aria-hidden="false" data-cool="dude" data-very-rad="gal"></div>
 ```
 
 ## Setup

--- a/src/DOMAttributeDescriptors.js
+++ b/src/DOMAttributeDescriptors.js
@@ -138,6 +138,7 @@ const attributes = {
   value: USE_PROPERTY_HOOK,
 
   // X-* attributes
+  aria: IS_STAR,
   data: IS_STAR,
 }
 

--- a/test/examples/AriaTags-test.js
+++ b/test/examples/AriaTags-test.js
@@ -1,0 +1,18 @@
+const test = require(`tape`)
+const Yolk = require(`yolk`) // eslint-disable-line no-unused-vars
+const renderInDoc = require(`../helpers/renderInDoc`)
+
+test(`AriaTags: using aria tags`, t => {
+  t.plan(4)
+  t.timeoutAfter(100)
+
+  const component = <div aria={{hidden: false, labeledby: `parentId`}} />
+  const [node, cleanup] = renderInDoc(component)
+
+  t.equal(node.hasAttribute(`aria-hidden`), true)
+  t.equal(node.getAttribute(`aria-hidden`), `false`)
+  t.equal(node.hasAttribute(`aria-labeledby`), true)
+  t.equal(node.getAttribute(`aria-labeledby`), `parentId`)
+
+  cleanup()
+})


### PR DESCRIPTION
> **ARIA** is a set of special accessibility attributes which can be added to any markup, but is especially suited to HTML. The `role` attribute defines what the general type of object is (such as an `article`, `alert`, or `slider`). Additional ARIA attributes provide other useful properties, such as a description for a form or the current value of a progressbar.

See: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA

Example

```js
export default function Menu(props, children) {
  const aria = {
    hidden: false,
    haspopup: true
  };

  return (
    <div role='menubar'>
      <div role='menuitem'
           aria={aria}>
        <span>Menu</span>
        <div role='menu'>
           {children}
        </div>
      </div>
    </div>
  );
}