### PR TITLE
Don't rely on the DOM to build components

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lodash.kebabcase": "3.0.1",
     "parse-tag": "1.0.0",
     "rx": "^4.0.0",
-    "yolk-virtual-dom": "3.0.3"
+    "yolk-virtual-dom": "4.1.0"
   },
   "browserify-shim": {
     "rx": "global:Rx"

--- a/src/YolkBaseComponent.js
+++ b/src/YolkBaseComponent.js
@@ -31,10 +31,11 @@ YolkBaseComponent.prototype = {
   init () {
     this._props$ = new CompositePropSubject(this._props)
     this._children$ = new Rx.BehaviorSubject(this._children)
+    this._innerComponent = new YolkBaseInnerComponent(this.id)
 
     const props$ = wrapObject(this._props$.asDistinctObservableObject(), {wrapToJS: true}).map(transformProperties)
     const children$ = this._children$.flatMapLatest(c => wrapObject(c, {wrapToJS: true})).map(flatten)
-    const innerComponent = new YolkBaseInnerComponent(this.id)
+    const innerComponent = this._innerComponent
 
     this._disposable =
       props$.combineLatest(children$)
@@ -43,12 +44,11 @@ YolkBaseComponent.prototype = {
         (err) => {throw err}
       )
 
-    const node = innerComponent.createNode()
-
-    return node
+    return innerComponent.createVirtualNode()
   },
 
   postinit (node) {
+    this._innerComponent.setNode(node)
     mountable.emitMount(node, this._props.onMount)
   },
 
@@ -56,6 +56,7 @@ YolkBaseComponent.prototype = {
     this._props$ = previous._props$
     this._children$ = previous._children$
     this._disposable = previous._disposable
+    this._innerComponent = previous._innerComponent
 
     this._props$.onNext(this._props)
     this._children$.onNext(this._children)

--- a/src/YolkBaseInnerComponent.js
+++ b/src/YolkBaseInnerComponent.js
@@ -1,5 +1,4 @@
 const h = require(`yolk-virtual-dom/h`)
-const create = require(`yolk-virtual-dom/create-element`)
 const diff = require(`yolk-virtual-dom/diff`)
 const patch = require(`yolk-virtual-dom/patch`)
 const generateUid = require(`./generateUid`)
@@ -14,10 +13,14 @@ function YolkBaseInnerComponent (tag) {
 }
 
 YolkBaseInnerComponent.prototype = {
-  createNode () {
+  createVirtualNode () {
     this._vNode = h(this._tag, this._props, this._children)
-    this._node = create(this._vNode)
-    return this._node
+    return this._vNode
+  },
+
+  setNode (node) {
+    this._node = node
+    this.update(this._props, this._children)
   },
 
   update (props, children) {

--- a/src/YolkCompositeComponent.js
+++ b/src/YolkCompositeComponent.js
@@ -1,5 +1,4 @@
 const Rx = require(`rx`)
-const create = require(`yolk-virtual-dom/create-element`)
 const YolkCompositeFunctionWrapper = require(`./YolkCompositeFunctionWrapper`)
 const CompositePropSubject = require(`./CompositePropSubject`)
 
@@ -33,7 +32,7 @@ YolkCompositeComponent.prototype = {
     const fn = this._fn
     this._component = YolkCompositeFunctionWrapper.create(fn, props$, children$)
 
-    return create(this._component.getVirtualNode())
+    return this._component.getVirtualNode()
   },
 
   update (previous) {

--- a/src/YolkCustomComponent.js
+++ b/src/YolkCustomComponent.js
@@ -1,4 +1,3 @@
-const create = require(`yolk-virtual-dom/create-element`)
 const wrapObject = require(`./wrapObject`)
 const addProperties = require(`./addProperties`)
 const YolkBaseComponent = require(`./YolkBaseComponent`)
@@ -29,11 +28,9 @@ YolkCustomComponent.prototype = {
   },
 
   init () {
-    const node = create(this._child)
-
     this._props$ = new CompositePropSubject(this._props)
 
-    return node
+    return this._child
   },
 
   postinit (node) {

--- a/src/YolkRootComponent.js
+++ b/src/YolkRootComponent.js
@@ -15,7 +15,7 @@ YolkRootComponent.prototype = {
   type: `Widget`,
 
   init () {
-    return create(this._child)
+    return this._child
   },
 
   update (previous, node) {

--- a/test/examples/LifecycleHooks-test.js
+++ b/test/examples/LifecycleHooks-test.js
@@ -10,7 +10,7 @@ test(`LifecycleHooks: will run code after the component mounts`, t => {
 
   function onMount (ev) {
     t.equal(ev.target.tagName, `STRONG`)
-    cleanup()
+    setTimeout(cleanup, 0)
   }
 
   const component = <strong onMount={onMount} />

--- a/test/examples/WrapCustomComponent-test.js
+++ b/test/examples/WrapCustomComponent-test.js
@@ -8,11 +8,7 @@ class CustomStub {
   }
 
   init () {
-    const node = document.createElement(`strong`)
-
-    node.innerHTML = `hello world!`
-
-    return node
+    return Yolk.h(`strong`, null, `hello world!`)
   }
 
   update (previous, node) {

--- a/test/examples/WrapCustomWidgetWithChildren-test.js
+++ b/test/examples/WrapCustomWidgetWithChildren-test.js
@@ -1,7 +1,7 @@
 const test = require(`tape`)
 const Yolk = require(`yolk`) // eslint-disable-line no-unused-vars
 
-const {h, create} = require(`yolk-virtual-dom`)
+const {h} = require(`yolk-virtual-dom`)
 const renderInDoc = require(`../helpers/renderInDoc`)
 
 class CustomStub {
@@ -11,8 +11,7 @@ class CustomStub {
   }
 
   init () {
-    const vNode = h(`div`, null, this.children)
-    return create(vNode)
+    return h(`div`, null, this.children)
   }
 
   update (previous, node) {

--- a/test/unit/YolkBaseComponent-test.js
+++ b/test/unit/YolkBaseComponent-test.js
@@ -8,7 +8,7 @@ test(`YolkBaseComponent: returns a base component`, t => {
   t.timeoutAfter(100)
 
   const instance = new YolkBaseComponent(`p`, {height: 5}, [])
-  const node = instance.init()
+  const [node, cleanup] = renderInDoc(instance)
 
   t.equal(node.tagName, `P`)
   t.equal(node.getAttribute(`height`), `5`)
@@ -20,6 +20,8 @@ test(`YolkBaseComponent: returns a base component`, t => {
   t.equal(node.tagName, `P`)
   t.equal(node.getAttribute(`height`), `10`)
   t.equal(node.innerHTML, `hello`)
+
+  cleanup()
 })
 
 test(`YolkBaseComponent: does not apply new prop keys`, t => {
@@ -27,7 +29,7 @@ test(`YolkBaseComponent: does not apply new prop keys`, t => {
   t.timeoutAfter(100)
 
   const instance = new YolkBaseComponent(`p`, {height: 5}, [])
-  const node = instance.init()
+  const [node, cleanup] = renderInDoc(instance)
 
   const patched = new YolkBaseComponent(`p`, {width: 10}, [`hello`])
   patched.update(instance)
@@ -35,6 +37,8 @@ test(`YolkBaseComponent: does not apply new prop keys`, t => {
   t.equal(node.tagName, `P`)
   t.equal(node.getAttribute(`height`), `null`)
   t.notOk(node.getAttribute(`width`))
+
+  cleanup()
 })
 
 test(`YolkBaseComponent: listens for mount and umount when defined`, t => {


### PR DESCRIPTION
Upgrade to `yolk-virtual-dom@4.1.0` so that widget do not return DOM nodes. Gets one step closer to enabling server rendering.