### PR TITLE
Clarify types and enable flow for node proxies

### DIFF
--- a/src/ElementProxy.js
+++ b/src/ElementProxy.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 import document from 'global/document'
 import {descriptors} from './propertyDescriptors'
 import {addEventListener, removeEventListener} from './eventDelegator'
@@ -5,11 +7,12 @@ import {emitMount, emitUnmount} from './mountable'
 import {isDefined} from './is'
 import {get} from './get'
 import {set} from './set'
+import {NodeProxy} from './types'
 
-export class NodeProxy {
-  _node: HTMLElement | Text;
+export class ElementProxy {
+  _node: HTMLElement;
 
-  constructor (node: HTMLElement | Text) {
+  constructor (node: HTMLElement) {
     this._node = node
   }
 
@@ -128,22 +131,17 @@ export class NodeProxy {
     set(node, computed, undefined)
   }
 
-  static createTextNode (content: string): NodeProxy {
-    const node: Text = document.createTextNode(content)
-    return new NodeProxy(node)
-  }
-
-  static createElement (tagName: string): NodeProxy {
+  static createElement (tagName: string): ElementProxy {
     const node: HTMLElement = document.createElement(tagName)
-    return new NodeProxy(node)
+    return new ElementProxy(node)
   }
 
-  static querySelector (selector: string): NodeProxy {
+  static querySelector (selector: string): ElementProxy {
     const node: HTMLElement = document.querySelector(selector)
-    return new NodeProxy(node)
+    return new ElementProxy(node)
   }
 
-  static fromElement (node: HTMLElement): NodeProxy {
-    return new NodeProxy(node)
+  static fromElement (node: HTMLElement): ElementProxy {
+    return new ElementProxy(node)
   }
 }

--- a/src/TextProxy.js
+++ b/src/TextProxy.js
@@ -1,0 +1,20 @@
+/* @flow */
+
+import document from 'global/document'
+
+export class TextProxy {
+  _node: Text;
+
+  constructor (node: Text) {
+    this._node = node
+  }
+
+  setValue (value : string) : void {
+    this._node.nodeValue = value
+  }
+
+  static createTextNode (content: string): TextProxy {
+    const node: Text = document.createTextNode(content)
+    return new TextProxy(node)
+  }
+}

--- a/src/VirtualComponent.js
+++ b/src/VirtualComponent.js
@@ -11,8 +11,8 @@ import {set} from './set'
 
 import type {Observable} from 'rxjs/Observable'
 import type {Subject} from 'rxjs/Subject'
-import type {NodeProxy} from './NodeProxy'
-import type {VirtualElement} from './types'
+import type {ElementProxy} from './ElementProxy'
+import type {VirtualNode} from './types'
 
 const createCompositeArraySubject = createCompositeSubject(createObservableFromArray)
 
@@ -28,14 +28,14 @@ export class VirtualComponent {
   key: string | void;
   tagName: string;
   _props: Object;
-  _children: Array<Observable|VirtualElement>;
+  _children: Array<Observable|VirtualNode>;
   _fn: Function;
   _eventHandlers: Array<Subject>;
   _props$: Subject<Object>;
-  _children$: Subject<Array<Observable|VirtualElement>>;
-  _instance: VirtualElement;
+  _children$: Subject<Array<Observable|VirtualNode>>;
+  _instance: VirtualNode;
 
-  constructor (fn: Function, tagName: string, props: Object, children: Array<VirtualElement>, key?: string) {
+  constructor (fn: Function, tagName: string, props: Object, children: Array<VirtualNode>, key?: string) {
     this.key = key
     this.tagName = tagName
     this._fn = fn
@@ -44,7 +44,7 @@ export class VirtualComponent {
     this._eventHandlers = []
   }
 
-  getProxy (): NodeProxy {
+  getProxy (): ElementProxy {
     return this._instance.getProxy()
   }
 
@@ -95,7 +95,7 @@ export class VirtualComponent {
   moveChild (__child: any, __index: any): void {}
   removeChild (__child: any): void {}
 
-  static create (fn: Function, props: Object, children: Array<Observable|VirtualElement>): VirtualComponent {
+  static create (fn: Function, props: Object, children: Array<Observable|VirtualNode>): VirtualComponent {
     const uid = appendUidToComponent(fn)
 
     return new VirtualComponent(fn, uid, props, children, props.key)

--- a/src/VirtualElement.js
+++ b/src/VirtualElement.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {NodeProxy} from './NodeProxy'
+import {ElementProxy} from './ElementProxy'
 import {wrapText} from './wrapText'
 import {parseTag} from './parseTag'
 import {batchInsertMessages} from './batchInsertMessages'
@@ -16,24 +16,24 @@ import {set} from './set'
 import type {Observable} from 'rxjs/Observable'
 import type {Subject} from 'rxjs/Subject'
 import type {Subscription} from 'rxjs/Subscription'
-import type {VirtualElement, NodeProxyDecorator} from './types'
+import type {VirtualNode, ElementProxyDecorator} from './types'
 
 import 'rxjs/add/operator/map'
 
 const createCompositePropSubject = createCompositeSubject(createNodeProps)
 const createCompositeArraySubject = createCompositeSubject(createObservableFromArray)
 
-export class VirtualNode {
+export class VirtualElement {
   key: string | void;
   tagName: string;
   _props: Object;
-  _children: Array<VirtualElement>;
+  _children: Array<VirtualNode>;
   _subscriptions: Array<Subscription>;
   _props$: Subject<Object>;
-  _children$: Subject<Array<Observable|VirtualElement>>;
-  _proxy: NodeProxy;
+  _children$: Subject<Array<Observable|VirtualNode>>;
+  _proxy: ElementProxy;
 
-  constructor (tagName: string, props: Object, children: Array<VirtualElement>, key?: string) {
+  constructor (tagName: string, props: Object, children: Array<VirtualNode>, key?: string) {
     this.key = key
     this.tagName = tagName
     this._props = props
@@ -41,16 +41,16 @@ export class VirtualNode {
     this._subscriptions = []
   }
 
-  getProxy (): NodeProxy {
+  getProxy (): ElementProxy {
     return this._proxy
   }
 
   initialize (): void {
-    const proxy: NodeProxy = this._proxy = NodeProxy.createElement(this.tagName)
+    const proxy: ElementProxy = this._proxy = ElementProxy.createElement(this.tagName)
     const props$: Subject<Object> = this._props$ = createCompositePropSubject(this._props)
     const children$: Subject<Array<VirtualNode>> = this._children$ = createCompositeArraySubject(this._children)
 
-    const proxyDecorator: NodeProxyDecorator = {
+    const proxyDecorator: ElementProxyDecorator = {
       insertChild (child: VirtualNode, index: number): void {
         return batchInsertMessages(queue => {
           child.initialize()
@@ -114,8 +114,8 @@ export class VirtualNode {
     const tagName: string = parseTag(_tagName, props)
     const key: string = props.key || null
 
-    return new VirtualNode(tagName, props, children, key)
+    return new VirtualElement(tagName, props, children, key)
   }
 }
 
-set(VirtualNode.prototype, $$virtual, true)
+set(VirtualElement.prototype, $$virtual, true)

--- a/src/VirtualText.js
+++ b/src/VirtualText.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {NodeProxy} from './NodeProxy'
+import {TextProxy} from './TextProxy'
 import {$$virtual} from './symbol'
 import {set} from './set'
 
@@ -8,23 +8,23 @@ export class VirtualText {
   key: void;
   tagName: string;
   _content: string;
-  _proxy: NodeProxy;
+  _proxy: TextProxy;
 
   constructor (content: string) {
     this._content = content
   }
 
-  getProxy (): NodeProxy {
+  getProxy (): TextProxy {
     return this._proxy
   }
 
   initialize (): void {
-    this._proxy = NodeProxy.createTextNode(this._content)
+    this._proxy = TextProxy.createTextNode(this._content)
   }
 
   patch (next: VirtualText): void {
-    const proxy: NodeProxy = next._proxy = this._proxy
-    proxy.setAttribute(`textContent`, next._content)
+    const proxy: TextProxy = next._proxy = this._proxy
+    proxy.setValue(next._content)
   }
 
   afterInsert (): void {}

--- a/src/__test__/TextProxy.test.js
+++ b/src/__test__/TextProxy.test.js
@@ -1,0 +1,22 @@
+/* @flow */
+
+import {TextProxy} from '../TextProxy'
+
+describe(`TextProxy`, () => {
+  it(`creates a text node`, () => {
+    const expectedText = `expected-text`
+    const textProxy = TextProxy.createTextNode(expectedText)
+
+    const node = textProxy._node
+    assert.equal(node.nodeType, Node.TEXT_NODE)
+    assert.equal(node.nodeValue, expectedText)
+  })
+
+  it(`can set its node's text`, () => {
+    const textProxy = TextProxy.createTextNode(`initial-text`)
+
+    const expectedText = `expected-text`
+    textProxy.setValue(expectedText)
+    assert.equal(textProxy._node.nodeValue, expectedText)
+  })
+})

--- a/src/__test__/createPatchChildren.test.js
+++ b/src/__test__/createPatchChildren.test.js
@@ -1,7 +1,7 @@
 /* @flow weak */
 
 import sinon from 'sinon/pkg/sinon'
-import {VirtualNode} from '../VirtualNode'
+import {VirtualNode} from '../types'
 import {createPatchChildren} from '../createPatchChildren'
 import {h} from '../h'
 

--- a/src/__test__/createPatchProperties.test.js
+++ b/src/__test__/createPatchProperties.test.js
@@ -1,12 +1,12 @@
 /* @flow weak */
 
 import {createPatchProperties} from '../createPatchProperties'
-import {NodeProxy} from '../NodeProxy'
+import {ElementProxy} from '../ElementProxy'
 import {get} from '../get'
 
 describe(`patchProperties`, () => {
   it(`sets attributes on a node`, () => {
-    const proxy = NodeProxy.createElement(`div`)
+    const proxy = ElementProxy.createElement(`div`)
     const patchProperties = createPatchProperties(proxy)
     const node = proxy._node
 

--- a/src/batchInsertMessages.js
+++ b/src/batchInsertMessages.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type {VirtualNode} from './VirtualNode'
+import type {VirtualNode} from './types'
 
 type Scope = {
   batchInProgress: boolean;

--- a/src/createPatchChildren.js
+++ b/src/createPatchChildren.js
@@ -4,11 +4,11 @@ import dift, {CREATE, UPDATE, MOVE, REMOVE} from 'dift'
 
 import {keyIndex} from './keyIndex'
 
-import type {VirtualElement, NodeProxyDecorator} from './types'
+import type {VirtualNode, ElementProxyDecorator} from './types'
 
 const keyFn: Function = a => a.key
 
-const patch = (decorator: NodeProxyDecorator, previousChildren: Array<VirtualElement>, nextChildren: Array<VirtualElement>): void => {
+const patch = (decorator: ElementProxyDecorator, previousChildren: Array<VirtualNode>, nextChildren: Array<VirtualNode>): void => {
   const previousIndex = keyIndex(previousChildren)
   const nextIndex = keyIndex(nextChildren)
 
@@ -34,10 +34,10 @@ const patch = (decorator: NodeProxyDecorator, previousChildren: Array<VirtualEle
   dift(previousIndex, nextIndex, apply, keyFn)
 }
 
-export const createPatchChildren = (decorator: NodeProxyDecorator): Function => {
-  let previous: Array<VirtualElement> = []
+export const createPatchChildren = (decorator: ElementProxyDecorator): Function => {
+  let previous: Array<VirtualNode> = []
 
-  return (next: Array<VirtualElement>): Array<VirtualElement> => {
+  return (next: Array<VirtualNode>): Array<VirtualNode> => {
     if (previous.length !== 0 || next.length !== 0) {
       patch(decorator, previous, next)
     }

--- a/src/createPatchProperties.js
+++ b/src/createPatchProperties.js
@@ -1,27 +1,27 @@
 /* @flow */
 
-import type {NodeProxy} from './NodeProxy'
+import type {ElementProxy} from './ElementProxy'
 
-function patchProperties (nodeProxy: NodeProxy, props: Object, oldProps: Object): Object {
+function patchProperties (elementProxy: ElementProxy, props: Object, oldProps: Object): Object {
   for (const key in props) {
     if (props[key] !== oldProps[key]) {
-      nodeProxy.setAttribute(key, props[key])
+      elementProxy.setAttribute(key, props[key])
     }
   }
 
   for (const key in oldProps) {
     if (!(key in props)) {
-      nodeProxy.removeAttribute(key)
+      elementProxy.removeAttribute(key)
     }
   }
 
   return props
 }
 
-export function createPatchProperties (nodeProxy: NodeProxy): Function {
+export function createPatchProperties (elementProxy: ElementProxy): Function {
   let previous: Object = {}
 
   return (next: Object): void => {
-    previous = patchProperties(nodeProxy, next, previous)
+    previous = patchProperties(elementProxy, next, previous)
   }
 }

--- a/src/h.js
+++ b/src/h.js
@@ -1,19 +1,19 @@
 /* @flow weak */
 
 import {VirtualComponent} from './VirtualComponent'
-import {VirtualNode} from './VirtualNode'
+import {VirtualElement} from './VirtualElement'
 import {isString} from './is'
 import {flatten} from './flatten'
 import {emptyObject} from './emptyObject'
 
-import type {VirtualElement} from './types'
+import type {VirtualNode} from './types'
 
-export function h (tagName, _props, ..._children): VirtualElement {
+export function h (tagName, _props, ..._children): VirtualNode {
   const children = flatten(_children)
   const props = _props || emptyObject
 
   if (isString(tagName)) {
-    return VirtualNode.create(tagName, props, children)
+    return VirtualElement.create(tagName, props, children)
   }
 
   return VirtualComponent.create(tagName, props, children)

--- a/src/keyIndex.js
+++ b/src/keyIndex.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type {VirtualNode} from './VirtualNode'
+import type {VirtualNode} from './types'
 
 export function keyIndex (children: Array<VirtualNode>): Array<Object> {
   const len: number = children.length

--- a/src/render.js
+++ b/src/render.js
@@ -1,16 +1,15 @@
 /* @flow */
 
 import {batchInsertMessages} from './batchInsertMessages'
-import {NodeProxy} from './NodeProxy'
+import {ElementProxy} from './ElementProxy'
+import {VirtualElement} from './VirtualElement'
 import {isDefined} from './is'
 import {$$root} from './symbol'
 import {get} from './get'
 import {set} from './set'
 
-import type {VirtualElement} from './types'
-
 export function render (vnode: VirtualElement, node: HTMLElement): void {
-  const containerProxy: NodeProxy = NodeProxy.fromElement(node)
+  const containerProxy: ElementProxy = ElementProxy.fromElement(node)
   const previous: VirtualElement = get(node, $$root)
 
   if (isDefined(previous)) {

--- a/src/types.js
+++ b/src/types.js
@@ -1,13 +1,13 @@
-import type {VirtualNode} from './VirtualNode'
+import type {VirtualElement} from './VirtualElement'
 import type {VirtualComponent} from './VirtualComponent'
 import type {VirtualText} from './VirtualText'
-import type {NodeProxy} from './NodeProxy'
+import type {ElementProxy} from './ElementProxy'
 import type {TextProxy} from './TextProxy'
 
-export type VirtualElement = VirtualNode | VirtualComponent | VirtualText
-export type VirtualProxy = TextProxy | NodeProxy
+export type VirtualNode = VirtualElement | VirtualComponent | VirtualText
+export type NodeProxy = ElementProxy | TextProxy
 
-export type NodeProxyDecorator = {
+export type ElementProxyDecorator = {
   insertChild (child: VirtualNode, index: number): void;
   updateChild (previous: VirtualNode, next: VirtualNode): void;
   moveChild (previous: VirtualNode, next: VirtualNode, index: number): void;


### PR DESCRIPTION
Hi @garbles,

I was happy to see the addition of `VirtualText`, noticed your commit about disabling flow in `NodeProxy`, and decided to take a look at the flow issue. I am wondering whether you will want to keep a single proxy type, but I ended up thinking we should have separate proxy types for element and text because they are simply different things.

Here's a summary of my changes:
* Split `NodeProxy` into `ElementProxy` and `TextProxy`
* Enabled flow for both proxy modules
* Set text node content by setting `nodeValue` rather than `textContent` because it is more direct
* Added unit tests for `TextProxy` (just 2 test cases)
* Renamed `VirtualNode` to `VirtualElement` for clarity because both text and elements are nodes in the DOM.
* Renamed the union `VirtualElement` to `VirtualNode` in `types.js`
* Renamed `NodeProxyDecorator` to `ElementProxyDecorator` in `types.js`


If you are open to these changes and how I wrote the `TextProxy` tests, I can also write tests for `ElementProxy` either before or after landing this.

What do you think?