### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
Yolk has different editor preferences than my defaults, so I created this while working on yesterday's PR.

I left out the setting for line endings since this repo doesn't take a clear stance in the form of a .gitattributes file. I'm not familiar with the pros and cons of the options, or I'd suggest something.