### PR TITLE
When element is null or undefined, use empty string as wrapper element

### DIFF
--- a/src/wrapText.js
+++ b/src/wrapText.js
@@ -10,6 +10,10 @@ function wrap (obj: any): VirtualElement {
     return obj
   }
 
+  if (obj === null || obj === undefined) {
+    return VirtualText.create(``)
+  }
+
   return VirtualText.create(obj.toString())
 }
 


### PR DESCRIPTION
Fixes #95