### PR TITLE
Fix CustomEvent to import global/document

### DIFF
--- a/src/CustomEvent.js
+++ b/src/CustomEvent.js
@@ -1,3 +1,5 @@
+import document from 'global/document'
+
 export const CustomEvent = global.CustomEvent || (() => {
   const DEFAULT_PARAMS = {bubbles: false, cancelable: false, detail: undefined}
 


### PR DESCRIPTION
Hi, this is just a quick fix to import `global/document` in `src/CustomEvent` like we do everywhere else.