### PR TITLE
Check if child has destroy member before calling

### DIFF
--- a/src/VirtualElement.js
+++ b/src/VirtualElement.js
@@ -107,7 +107,9 @@ export class VirtualElement {
 
   destroy (): void {
     this._subscriptions.forEach(s => s.unsubscribe())
-    this._children.forEach(c => c.destroy())
+    this._children.forEach(c => {
+      if (c && c.destroy !== undefined) c.destroy()
+    })
   }
 
   static create (_tagName: string, props: Object, children: Array<VirtualNode|Observable>): VirtualNode {


### PR DESCRIPTION
Fixes issue #85 

However, this seems more like a patch as I think all children should have a destroy method.

In my application, if the child is only a text node (`<div>foobar</div>`) the child, the destroy method receives the child as a raw string which does not have a destroy method:

```
jsx component:
<div>foobar</div>
```
```
destroy (): void {
    this._subscriptions.forEach(s => s.unsubscribe())
    this._children.forEach(c => {
     // c === 'foobar' which will not have a destroy method
      if (c && c.destroy !== undefined) c.destroy() // now checks for destroyable member
    })
  }
``` 