### PR TITLE
Enable sourcemaps for test

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -43,7 +43,7 @@ module.exports = config => {
     files: [`src/**/*.test.js`],
 
     preprocessors: {
-      'src/**/*.test.js': [`webpack`],
+      'src/**/*.test.js': [`webpack`, `sourcemap`],
     },
 
     colors: true,

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "karma-growl-reporter": "0.1.1",
     "karma-mocha": "0.2.2",
     "karma-mocha-reporter": "2.0.0",
+    "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "1.7.0",
     "mocha": "2.4.5",
     "sinon": "2.0.0-pre",


### PR DESCRIPTION
Hey @garbles, this is simple PR to allow us to see real line numbers with test failures. Unfortunately, this PR does not come with failing tests :) But you can see it easily by breaking one.