### PR TITLE
Test ElementProxy DOM placement and querySelector

### DIFF
--- a/src/ElementProxy.js
+++ b/src/ElementProxy.js
@@ -24,14 +24,14 @@ export class ElementProxy {
     emitUnmount(this._node, fn)
   }
 
-  children (): HTMLCollection {
-    return this._node.children
+  childNodes (): NodeList {
+    return this._node.childNodes
   }
 
   replaceChild (childProxy: NodeProxy, index: number): void {
     const node = this._node
     const child = childProxy._node
-    const replaced = node.children[index]
+    const replaced = node.childNodes[index]
 
     if (isDefined(replaced)) {
       node.replaceChild(child, replaced)
@@ -43,7 +43,7 @@ export class ElementProxy {
   insertChild (childProxy: NodeProxy, index: number): void {
     const node = this._node
     const child = childProxy._node
-    const before: Node = node.children[index]
+    const before: Node = node.childNodes[index]
 
     if (isDefined(before)) {
       node.insertBefore(child, before)

--- a/src/ElementProxy.js
+++ b/src/ElementProxy.js
@@ -136,9 +136,9 @@ export class ElementProxy {
     return new ElementProxy(node)
   }
 
-  static querySelector (selector: string): ElementProxy {
+  static querySelector (selector: string): ?ElementProxy {
     const node: HTMLElement = document.querySelector(selector)
-    return new ElementProxy(node)
+    return node ? new ElementProxy(node) : null
   }
 
   static fromElement (node: HTMLElement): ElementProxy {

--- a/src/__test__/ElementProxy.test.js
+++ b/src/__test__/ElementProxy.test.js
@@ -1,0 +1,160 @@
+/* @flow */
+
+import document from 'global/document'
+import {ElementProxy} from '../ElementProxy'
+import {TextProxy} from '../TextProxy'
+
+describe(`ElementProxy`, () => {
+  it(`creates an element node`, () => {
+    const createdTagName = `div`
+    const elementProxy = ElementProxy.createElement(createdTagName)
+
+    const node = elementProxy._node
+    assert.equal(node.nodeType, Node.ELEMENT_NODE)
+
+    const expectedTagName = createdTagName.toUpperCase()
+    assert.equal(node.tagName, expectedTagName)
+  })
+
+  const createTestElement = () => ElementProxy.createElement(`div`)
+  const createTestTextNode = () => TextProxy.createTextNode(`some-text`)
+
+  it(`appends a child`, () => {
+    const testAppend = (createTestProxy, createTestProxy2) => {
+      const parentProxy = ElementProxy.createElement(`div`)
+      const children = parentProxy.children()
+
+      assert.equal(children.length, 0)
+
+      const childProxy = createTestProxy()
+      parentProxy.insertChild(childProxy, children.length)
+
+      assert.equal(children.length, 1)
+      assert.equal(children[0], childProxy._node)
+
+      const childProxy2 = createTestProxy2()
+      parentProxy.insertChild(childProxy2, children.length)
+
+      assert.equal(children.length, 2)
+      assert.equal(children[1], childProxy2._node)
+    }
+
+    testAppend(createTestElement, createTestElement)
+    testAppend(createTestElement, createTestTextNode)
+    testAppend(createTestTextNode, createTestElement)
+    testAppend(createTestTextNode, createTestTextNode)
+  })
+
+  it(`inserts a child before another child`, () => {
+    const testInsertBefore = (createBeforeNode, createInsertedNode) => {
+      const parentProxy = ElementProxy.createElement(`div`)
+      const children = parentProxy.children()
+
+      const beforeNodeProxy = createBeforeNode()
+      parentProxy.insertChild(beforeNodeProxy, 0)
+
+      // Confirm assumptions
+      assert.equal(children.length, 1)
+      assert.equal(children[0], beforeNodeProxy._node)
+
+      const insertedNodeProxy = createInsertedNode()
+      parentProxy.insertChild(insertedNodeProxy, 0)
+
+      assert.equal(children.length, 2)
+      assert.equal(children[0], insertedNodeProxy._node)
+      assert.equal(children[1], beforeNodeProxy._node)
+    }
+
+    testInsertBefore(createTestElement, createTestElement)
+    testInsertBefore(createTestElement, createTestTextNode)
+    testInsertBefore(createTestTextNode, createTestElement)
+    testInsertBefore(createTestTextNode, createTestTextNode)
+  })
+
+  it(`replaces a child`, () => {
+    const testReplaceChild = (createNodeProxy, createReplacementProxy) => {
+      const parentProxy = ElementProxy.createElement(`div`)
+      const childProxies = [createNodeProxy(), createNodeProxy(), createNodeProxy()]
+      const children = parentProxy.children()
+
+      childProxies.forEach((childProxy, i) => parentProxy.insertChild(childProxy, i))
+
+      // Confirm assumptions
+      assert.ok(childProxies.every((childProxy, i) => childProxy._node === children[i]))
+
+      const replacementNode = createReplacementProxy()
+      parentProxy.replaceChild(replacementNode, 1)
+      const expectedChildProxies = [childProxies[0], replacementNode, childProxies[2]]
+      assert.ok(expectedChildProxies.every((expectedProxy, i) => expectedProxy._node === children[i]))
+    }
+
+    testReplaceChild(createTestElement, createTestElement)
+    testReplaceChild(createTestElement, createTestTextNode)
+    testReplaceChild(createTestTextNode, createTestElement)
+    testReplaceChild(createTestTextNode, createTestTextNode)
+  })
+
+  it(`removes a child`, () => {
+    const testRemoveChild = (createTestProxy, createTestProxy2) => {
+      const parentProxy = ElementProxy.createElement(`div`)
+      const children = parentProxy.children()
+
+      const childProxy = createTestProxy()
+
+      parentProxy.insertChild(childProxy, children.length)
+      assert.equal(children.length, 1)
+      assert.equal(children[0], childProxy._node)
+      parentProxy.removeChild(childProxy)
+      assert.equal(children.length, 0)
+
+      const childProxy2 = createTestProxy2()
+
+      parentProxy.insertChild(childProxy, children.length)
+      parentProxy.insertChild(childProxy2, children.length)
+      assert.equal(children.length, 2)
+
+      parentProxy.removeChild(childProxy)
+      assert.equal(children.length, 1)
+      assert.equal(children[0], childProxy2._node)
+
+      parentProxy.removeChild(childProxy2)
+      assert.equal(children.length, 0)
+
+      parentProxy.insertChild(childProxy, children.length)
+      parentProxy.insertChild(childProxy2, children.length)
+      assert.equal(children.length, 2)
+
+      parentProxy.removeChild(childProxy2)
+      assert.equal(children.length, 1)
+      assert.equal(children[0], childProxy._node)
+
+      parentProxy.removeChild(childProxy)
+      assert.equal(children.length, 0)
+    }
+
+    testRemoveChild(createTestElement, createTestElement)
+    testRemoveChild(createTestElement, createTestTextNode)
+    testRemoveChild(createTestTextNode, createTestElement)
+    testRemoveChild(createTestTextNode, createTestTextNode)
+  })
+
+  it(`provides access to the children of its DOM node`, () => {
+    const parentNode = document.createElement(`div`)
+    const expectedChildren = [
+      document.createElement(`a`),
+      document.createElement(`p`),
+      document.createTextNode(`nested-text`),
+      document.createElement(`span`),
+    ]
+
+    expectedChildren.forEach(childNode => parentNode.appendChild(childNode))
+
+    const elementProxy = new ElementProxy(parentNode)
+    const actualChildren = elementProxy.children()
+
+    assert.equal(actualChildren.length, expectedChildren.length)
+    expectedChildren.forEach((expectedChildNode, i) => {
+      assert.equal(actualChildren[i], expectedChildNode)
+    })
+  })
+})

--- a/src/__test__/ElementProxy.test.js
+++ b/src/__test__/ElementProxy.test.js
@@ -22,21 +22,21 @@ describe(`ElementProxy`, () => {
   it(`appends a child`, () => {
     const testAppend = (createTestProxy, createTestProxy2) => {
       const parentProxy = ElementProxy.createElement(`div`)
-      const children = parentProxy.children()
+      const childNodes = parentProxy.childNodes()
 
-      assert.equal(children.length, 0)
+      assert.equal(childNodes.length, 0)
 
       const childProxy = createTestProxy()
-      parentProxy.insertChild(childProxy, children.length)
+      parentProxy.insertChild(childProxy, childNodes.length)
 
-      assert.equal(children.length, 1)
-      assert.equal(children[0], childProxy._node)
+      assert.equal(childNodes.length, 1)
+      assert.equal(childNodes[0], childProxy._node)
 
       const childProxy2 = createTestProxy2()
-      parentProxy.insertChild(childProxy2, children.length)
+      parentProxy.insertChild(childProxy2, childNodes.length)
 
-      assert.equal(children.length, 2)
-      assert.equal(children[1], childProxy2._node)
+      assert.equal(childNodes.length, 2)
+      assert.equal(childNodes[1], childProxy2._node)
     }
 
     testAppend(createTestElement, createTestElement)
@@ -48,21 +48,21 @@ describe(`ElementProxy`, () => {
   it(`inserts a child before another child`, () => {
     const testInsertBefore = (createBeforeNode, createInsertedNode) => {
       const parentProxy = ElementProxy.createElement(`div`)
-      const children = parentProxy.children()
+      const childNodes = parentProxy.childNodes()
 
       const beforeNodeProxy = createBeforeNode()
       parentProxy.insertChild(beforeNodeProxy, 0)
 
       // Confirm assumptions
-      assert.equal(children.length, 1)
-      assert.equal(children[0], beforeNodeProxy._node)
+      assert.equal(childNodes.length, 1)
+      assert.equal(childNodes[0], beforeNodeProxy._node)
 
       const insertedNodeProxy = createInsertedNode()
       parentProxy.insertChild(insertedNodeProxy, 0)
 
-      assert.equal(children.length, 2)
-      assert.equal(children[0], insertedNodeProxy._node)
-      assert.equal(children[1], beforeNodeProxy._node)
+      assert.equal(childNodes.length, 2)
+      assert.equal(childNodes[0], insertedNodeProxy._node)
+      assert.equal(childNodes[1], beforeNodeProxy._node)
     }
 
     testInsertBefore(createTestElement, createTestElement)
@@ -75,17 +75,17 @@ describe(`ElementProxy`, () => {
     const testReplaceChild = (createNodeProxy, createReplacementProxy) => {
       const parentProxy = ElementProxy.createElement(`div`)
       const childProxies = [createNodeProxy(), createNodeProxy(), createNodeProxy()]
-      const children = parentProxy.children()
+      const childNodes = parentProxy.childNodes()
 
       childProxies.forEach((childProxy, i) => parentProxy.insertChild(childProxy, i))
 
       // Confirm assumptions
-      assert.ok(childProxies.every((childProxy, i) => childProxy._node === children[i]))
+      assert.ok(childProxies.every((childProxy, i) => childProxy._node === childNodes[i]))
 
       const replacementNode = createReplacementProxy()
       parentProxy.replaceChild(replacementNode, 1)
       const expectedChildProxies = [childProxies[0], replacementNode, childProxies[2]]
-      assert.ok(expectedChildProxies.every((expectedProxy, i) => expectedProxy._node === children[i]))
+      assert.ok(expectedChildProxies.every((expectedProxy, i) => expectedProxy._node === childNodes[i]))
     }
 
     testReplaceChild(createTestElement, createTestElement)
@@ -97,39 +97,39 @@ describe(`ElementProxy`, () => {
   it(`removes a child`, () => {
     const testRemoveChild = (createTestProxy, createTestProxy2) => {
       const parentProxy = ElementProxy.createElement(`div`)
-      const children = parentProxy.children()
+      const childNodes = parentProxy.childNodes()
 
       const childProxy = createTestProxy()
 
-      parentProxy.insertChild(childProxy, children.length)
-      assert.equal(children.length, 1)
-      assert.equal(children[0], childProxy._node)
+      parentProxy.insertChild(childProxy, childNodes.length)
+      assert.equal(childNodes.length, 1)
+      assert.equal(childNodes[0], childProxy._node)
       parentProxy.removeChild(childProxy)
-      assert.equal(children.length, 0)
+      assert.equal(childNodes.length, 0)
 
       const childProxy2 = createTestProxy2()
 
-      parentProxy.insertChild(childProxy, children.length)
-      parentProxy.insertChild(childProxy2, children.length)
-      assert.equal(children.length, 2)
+      parentProxy.insertChild(childProxy, childNodes.length)
+      parentProxy.insertChild(childProxy2, childNodes.length)
+      assert.equal(childNodes.length, 2)
 
       parentProxy.removeChild(childProxy)
-      assert.equal(children.length, 1)
-      assert.equal(children[0], childProxy2._node)
+      assert.equal(childNodes.length, 1)
+      assert.equal(childNodes[0], childProxy2._node)
 
       parentProxy.removeChild(childProxy2)
-      assert.equal(children.length, 0)
+      assert.equal(childNodes.length, 0)
 
-      parentProxy.insertChild(childProxy, children.length)
-      parentProxy.insertChild(childProxy2, children.length)
-      assert.equal(children.length, 2)
+      parentProxy.insertChild(childProxy, childNodes.length)
+      parentProxy.insertChild(childProxy2, childNodes.length)
+      assert.equal(childNodes.length, 2)
 
       parentProxy.removeChild(childProxy2)
-      assert.equal(children.length, 1)
-      assert.equal(children[0], childProxy._node)
+      assert.equal(childNodes.length, 1)
+      assert.equal(childNodes[0], childProxy._node)
 
       parentProxy.removeChild(childProxy)
-      assert.equal(children.length, 0)
+      assert.equal(childNodes.length, 0)
     }
 
     testRemoveChild(createTestElement, createTestElement)
@@ -138,23 +138,23 @@ describe(`ElementProxy`, () => {
     testRemoveChild(createTestTextNode, createTestTextNode)
   })
 
-  it(`provides access to the children of its DOM node`, () => {
+  it(`provides access to the child nodes of its DOM node`, () => {
     const parentNode = document.createElement(`div`)
-    const expectedChildren = [
+    const expectedChildNodes = [
       document.createElement(`a`),
       document.createElement(`p`),
       document.createTextNode(`nested-text`),
       document.createElement(`span`),
     ]
 
-    expectedChildren.forEach(childNode => parentNode.appendChild(childNode))
+    expectedChildNodes.forEach(childNode => parentNode.appendChild(childNode))
 
     const elementProxy = new ElementProxy(parentNode)
-    const actualChildren = elementProxy.children()
+    const actualChildNodes = elementProxy.childNodes()
 
-    assert.equal(actualChildren.length, expectedChildren.length)
-    expectedChildren.forEach((expectedChildNode, i) => {
-      assert.equal(actualChildren[i], expectedChildNode)
+    assert.equal(actualChildNodes.length, expectedChildNodes.length)
+    expectedChildNodes.forEach((expectedChildNode, i) => {
+      assert.equal(actualChildNodes[i], expectedChildNode)
     })
   })
 })

--- a/src/__test__/ElementProxy.test.js
+++ b/src/__test__/ElementProxy.test.js
@@ -16,6 +16,23 @@ describe(`ElementProxy`, () => {
     assert.equal(node.tagName, expectedTagName)
   })
 
+  it(`provides proxied querySelector access to its document`, () => {
+    const elementNode = document.createElement(`div`)
+    elementNode.className = `testClass`
+    document.body.appendChild(elementNode)
+
+    try {
+      const elementProxy = ElementProxy.querySelector(`.testClass`)
+      assert.ok(elementProxy instanceof ElementProxy)
+      assert.equal(elementProxy && elementProxy._node, elementNode)
+
+      const nonexistentElementProxy = ElementProxy.querySelector(`.nonexistentClass`)
+      assert.equal(nonexistentElementProxy, null)
+    } finally {
+      elementNode.parentNode.removeChild(elementNode)
+    }
+  })
+
   const createTestElement = () => ElementProxy.createElement(`div`)
   const createTestTextNode = () => TextProxy.createTextNode(`some-text`)
 


### PR DESCRIPTION
Hi @garbles,

Here is a simpler PR with tests and related fixes for `ElementProxy` child placement and `querySelector`.

The main changes to `ElementProxy` are:
1. Use `this._node.childNodes` instead of `this._node.children` since `children` only includes elements.
2. Provide `childNodes` accessor rather than `children` for the reason mentioned above.
3. Fix `ElementProxy.querySelector` to return `null` instead of returning `new ElementProxy(null)` when `document.querySelector` returns `null`.

Hopefully, you don't feel too nickel and dimed by these PRs. Bite-sized is what I have time for. Just let me know if you'd like to do things differently.
